### PR TITLE
Add simple Paper.io-like web game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Simple Paper.io 2 Clone</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <canvas id="game" width="600" height="600"></canvas>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,107 @@
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+
+const boardSize = 600;
+const cellSize = 20;
+const cells = boardSize / cellSize;
+
+const player = {
+  x: 5,
+  y: 5,
+  dir: 'right',
+  color: 'lime',
+  trail: [],
+  territory: new Set(),
+};
+
+function posKey(x, y) {
+  return `${x},${y}`;
+}
+
+function drawBoard() {
+  ctx.fillStyle = '#111';
+  ctx.fillRect(0, 0, boardSize, boardSize);
+
+  // draw territory
+  ctx.fillStyle = player.color;
+  player.territory.forEach(key => {
+    const [x, y] = key.split(',').map(Number);
+    ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize);
+  });
+
+  // draw trail
+  ctx.fillStyle = 'yellow';
+  player.trail.forEach(p => {
+    ctx.fillRect(p.x * cellSize, p.y * cellSize, cellSize, cellSize);
+  });
+
+  // draw player
+  ctx.fillStyle = player.color;
+  ctx.fillRect(player.x * cellSize, player.y * cellSize, cellSize, cellSize);
+}
+
+function movePlayer() {
+  switch (player.dir) {
+    case 'up':
+      player.y -= 1; break;
+    case 'down':
+      player.y += 1; break;
+    case 'left':
+      player.x -= 1; break;
+    case 'right':
+      player.x += 1; break;
+  }
+
+  wrapPlayer();
+  addTrail();
+}
+
+function wrapPlayer() {
+  if (player.x < 0) player.x = cells - 1;
+  if (player.x >= cells) player.x = 0;
+  if (player.y < 0) player.y = cells - 1;
+  if (player.y >= cells) player.y = 0;
+}
+
+function addTrail() {
+  const key = posKey(player.x, player.y);
+  if (!player.territory.has(key)) {
+    player.trail.push({ x: player.x, y: player.y });
+    if (player.trail.some(p => p.x === player.startX && p.y === player.startY)) {
+      captureArea();
+    }
+  }
+}
+
+function captureArea() {
+  player.trail.forEach(p => {
+    const key = posKey(p.x, p.y);
+    player.territory.add(key);
+  });
+  player.trail = [];
+}
+
+function handleKey(e) {
+  switch (e.key) {
+    case 'ArrowUp': player.dir = 'up'; break;
+    case 'ArrowDown': player.dir = 'down'; break;
+    case 'ArrowLeft': player.dir = 'left'; break;
+    case 'ArrowRight': player.dir = 'right'; break;
+  }
+}
+
+function gameLoop() {
+  movePlayer();
+  drawBoard();
+  requestAnimationFrame(gameLoop);
+}
+
+function startGame() {
+  document.addEventListener('keydown', handleKey);
+  player.startX = player.x;
+  player.startY = player.y;
+  player.territory.add(posKey(player.x, player.y));
+  gameLoop();
+}
+
+startGame();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,15 @@
+body {
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background: #222;
+  color: #fff;
+  font-family: sans-serif;
+}
+
+#game {
+  background: #111;
+  border: 2px solid #555;
+}


### PR DESCRIPTION
## Summary
- implement a simple Paper.io 2 style game using canvas
- draw player, trail, and territory and capture area when loop completed

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f42a5d1888330a196a65a300a1797